### PR TITLE
Fix logic checking for disabled optgroups

### DIFF
--- a/lib/InputReaders.js
+++ b/lib/InputReaders.js
@@ -40,8 +40,8 @@ function getSelectValue (elem) {
 
         // Don't return options that are disabled or in a disabled optgroup
         !option.disabled &&
-        (!option.parentNode.disabled ||
-          option.parentNode.tagName.toLowerCase() === 'optgroup')) {
+        !(option.parentNode.disabled && option.parentNode.tagName.toLowerCase() === 'optgroup')
+    ) {
       // Get the specific value for the option
       value = option.value
 


### PR DESCRIPTION
The current logic would fail to fetch the value in case the select tag is disabled, if the option tag is a direct child of it.