### PR TITLE
Drop `matches-selector` dependency

### DIFF
--- a/lib/getInputElements.js
+++ b/lib/getInputElements.js
@@ -1,4 +1,3 @@
-import matchesSelector from 'matches-selector'
 import getElementType from './getElementType'
 
 export default function getInputElements (element, options) {
@@ -18,7 +17,7 @@ export default function getInputElements (element, options) {
 
       if (options.ignoredTypes) {
         for (let selector of options.ignoredTypes) {
-          if (matchesSelector(el, selector)) {
+          if (el.matches(selector)) {
             foundInIgnored = true
           }
         }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "rollup-watch": "^2.5.0"
   },
   "dependencies": {
-    "matches-selector": "^1.0.0"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
`Element.matches` is supported [everywhere](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#Browser_compatibility). If you want to support IE, the code can be slightly changed to use `.msMatchesSelector` if available (but IE is dead)

This improves ES Modules support because the dependency is not an ES Module