### PR TITLE
fix: reject prototype-pollution sinks in assignKeyValue

### DIFF
--- a/lib/assignKeyValue.js
+++ b/lib/assignKeyValue.js
@@ -1,7 +1,12 @@
+var UNSAFE_KEYS = ['__proto__', 'constructor', 'prototype']
+
 export default function assignKeyValue (obj, keychain, value) {
   if (!keychain) { return obj }
 
   var key = keychain.shift()
+
+  // Refuse to walk into prototype-pollution sinks.
+  if (UNSAFE_KEYS.indexOf(key) !== -1) { return obj }
 
   // build the current object we need to store data
   if (!obj[key]) {

--- a/test/serialize.nested.spec.js
+++ b/test/serialize.nested.spec.js
@@ -122,4 +122,38 @@ describe('serializing nested key names', () => {
       expect(result.foo.baz.quux).to.equal('qux')
     })
   })
+
+  describe('when an input name targets prototype-pollution sinks', () => {
+    it('does not pollute Object.prototype via __proto__', () => {
+      let form = domify(
+        '<form>' +
+        '<input type="text" name="__proto__[polluted]" value="yes">' +
+        '</form>'
+      )
+      let result = serialize(form)
+      expect({}.polluted).to.equal(undefined)
+      expect(result.polluted).to.equal(undefined)
+    })
+
+    it('does not pollute Object.prototype via constructor.prototype', () => {
+      let form = domify(
+        '<form>' +
+        '<input type="text" name="constructor[prototype][polluted]" value="yes">' +
+        '</form>'
+      )
+      let result = serialize(form)
+      expect({}.polluted).to.equal(undefined)
+      expect(result.polluted).to.equal(undefined)
+    })
+
+    it('does not pollute via a nested __proto__ segment', () => {
+      let form = domify(
+        '<form>' +
+        '<input type="text" name="foo[__proto__][polluted]" value="yes">' +
+        '</form>'
+      )
+      serialize(form)
+      expect({}.polluted).to.equal(undefined)
+    })
+  })
 })


### PR DESCRIPTION
A form input with a name like `__proto__[polluted]` would walk into
`Object.prototype` and assign onto it, polluting every plain object in
the running process. Bail out before descending into `__proto__`,
`constructor`, or `prototype` segments.

https://claude.ai/code/session_01BWpzEbVmEQvq5qNWxeLm6Q