### PR TITLE
Replace var with const for improved code quality

### DIFF
--- a/lib/assignKeyValue.js
+++ b/lib/assignKeyValue.js
@@ -1,4 +1,4 @@
-var UNSAFE_KEYS = ['__proto__', 'constructor', 'prototype']
+const UNSAFE_KEYS = ['__proto__', 'constructor', 'prototype']
 
 export default function assignKeyValue (obj, keychain, value) {
   if (!keychain) { return obj }

--- a/test/serialize.nested.spec.js
+++ b/test/serialize.nested.spec.js
@@ -125,29 +125,29 @@ describe('serializing nested key names', () => {
 
   describe('when an input name targets prototype-pollution sinks', () => {
     it('does not pollute Object.prototype via __proto__', () => {
-      let form = domify(
+      const form = domify(
         '<form>' +
         '<input type="text" name="__proto__[polluted]" value="yes">' +
         '</form>'
       )
-      let result = serialize(form)
+      const result = serialize(form)
       expect({}.polluted).to.equal(undefined)
       expect(result.polluted).to.equal(undefined)
     })
 
     it('does not pollute Object.prototype via constructor.prototype', () => {
-      let form = domify(
+      const form = domify(
         '<form>' +
         '<input type="text" name="constructor[prototype][polluted]" value="yes">' +
         '</form>'
       )
-      let result = serialize(form)
+      const result = serialize(form)
       expect({}.polluted).to.equal(undefined)
       expect(result.polluted).to.equal(undefined)
     })
 
     it('does not pollute via a nested __proto__ segment', () => {
-      let form = domify(
+      const form = domify(
         '<form>' +
         '<input type="text" name="foo[__proto__][polluted]" value="yes">' +
         '</form>'


### PR DESCRIPTION
This PR updates variable declarations to use `const` instead of `var` for better code quality and consistency with modern JavaScript best practices.

**Key changes:**
- Replaced `var` with `const` in `lib/assignKeyValue.js` for the `UNSAFE_KEYS` constant
- Replaced `let` with `const` in test file `test/serialize.nested.spec.js` for all local variables that are not reassigned

**Implementation details:**
- All variable declarations that are not reassigned have been converted to `const`, which provides better scoping and prevents accidental reassignment
- This change improves code clarity by making it explicit which variables are intended to be immutable
- No functional changes to the code logic or behavior

https://claude.ai/code/session_01MTTErEq6iprSa9vXdsvYuq